### PR TITLE
Fix for indefinitely kept open connections

### DIFF
--- a/app/proxy.js
+++ b/app/proxy.js
@@ -148,6 +148,11 @@ function proxyWork(context) {
     if (context.options.body) requestOut.write(context.options.body);
     requestOut.end();
   }
+
+  context.responseOut.on('close', function() {
+    requestOut.abort();
+    requestOut.socket.end();
+  });
 }
 
 // Function that allow to find the index of the requested server inside config.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AAAforREST",
   "description": "An HTTP reverse proxy to bring authentication, authorization and accounting to RESTful applications",
-  "version": "1.2015.0315",
+  "version": "1.2015.0420",
   "dependencies": {
     "ldapjs": ">=0.7.x",
     "winston": ">=0.8.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AAAforREST",
   "description": "An HTTP reverse proxy to bring authentication, authorization and accounting to RESTful applications",
-  "version": "1.20150315",
+  "version": "1.2015.0315",
   "dependencies": {
     "ldapjs": ">=0.7.x",
     "winston": ">=0.8.x",


### PR DESCRIPTION
Probably if no couchdb replication is done, the connections will go in timeout after a while. But it is correct to abort the connection to the server if the clients drop the connection.
It seems that the effective drop occurs only after the servers sends some data and node realizes that the connection is dropped. So with `heartbeat=10000` used by couchdb to listen for changes, it means after 10 seconds.