### PR TITLE
FIX: Avoid forging of CouchDB proxy auth.

### DIFF
--- a/app/proxy.js
+++ b/app/proxy.js
@@ -281,6 +281,13 @@ app.use(function(requestIn, responseOut, next) {
       agent: false
     };
     if (!site.preserveCredentials) delete context.options.headers.Authorization;
+    if (site.forwardedLoginHeader) {
+      for (var header in context.options.headers) {
+        if (header.toLowerCase()==site.forwardedLoginHeader.toLowerCase()) {
+          delete context.options.headers[header];
+        }
+      }
+    }
     parseHttpCredentials(context);
     var i = 0;
     var found = false;


### PR DESCRIPTION
This gives protection for now.

Comment : if `forwardedLoginHeader` is not used, but upstream server is configured with proxy auth, then the server is still exposed.

so I'd suggest a `protectedHeaders` list because we could also meet other cases, and/or use the salted token.