### PR TITLE
Proxy auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
 - couchapp push Cassandre-master http://localhost:5984/cassandre
 # Set up test fixture
 - curl -X PUT -d '"{couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {couch_httpd_auth, default_authentication_handler}"' localhost:5984/_config/httpd/authentication_handlers
+- curl -X PUT -d'"true"' localhost:5984/_config/couch_httpd_auth/proxy_use_secret
+- curl -X PUT -d'"secretkeyforcouchdbauthtoken"' localhost:5984/_config/couch_httpd_auth/secret
 - curl -X PUT localhost:5984/cassandre/iamlate -d '{"corpus":"Wonderland", "name":"I am late"}'
 - curl -X PUT localhost:5984/_users/org.couchdb.user:hatter -H 'Accept:application/json' -H 'Content-Type:application/json' -d '{"name":"hatter", "password":"teaparty", "roles":[], "type":"user"}'
 - curl -X PUT localhost:5984/_config/admins/carroll -d '"curiouser"'

--- a/app/proxy.js
+++ b/app/proxy.js
@@ -75,7 +75,7 @@ function authenticate(context, callback, shouldNotCatch) {
           for (var newHeader in addedHeaders) {
             // since roles are forced to a value, the role header is given by couch-proxy-auth
             // so can't be forged
-            //removeHeader(context.options.headers,newHeader);
+            removeHeader(context.options.headers,newHeader);
             context.options.headers[newHeader] = addedHeaders[newHeader];
           }
         }

--- a/app/proxy.js
+++ b/app/proxy.js
@@ -281,6 +281,13 @@ app.use(function(requestIn, responseOut, next) {
       agent: false
     };
     if (!site.preserveCredentials) delete context.options.headers.Authorization;
+    if (site.forwardedLoginHeader) {
+      for (var header in context.options.headers) {
+        if (header.toLowerCase()==site.forwardedLoginHeader.toLowerCase()) {
+          delete context.options.headers[header];
+        }
+      }
+    }
     parseHttpCredentials(context);
     var i = 0;
     var found = false;

--- a/conf/config.sample.js
+++ b/conf/config.sample.js
@@ -92,6 +92,16 @@ module.exports = {
      */
      //forwardedLoginHeader: null,
 
+    /**
+     * Use of protected CouchDB proxy auth X-Auth-CouchDB-*
+     * The secret must be configured on the server
+     * http://127.0.0.1:5984/_config/couch_httpd_auth/secret
+     * and 127.0.0.1:5984/_config/couch_httpd_auth/proxy_use_secret to true
+     * forwardedLoginRoles is optional
+     */
+     //forwardedLoginSecret: 'saltcommon',
+     //forwardedLoginRoles: 'comma,separated,list,or,roles'
+
      restricted: {
 
       /**

--- a/conf/config.sample.json
+++ b/conf/config.sample.json
@@ -55,7 +55,7 @@
     "authentication": [
       {"login": "hatter", "password": "unbirthday"}
     ],
-    "forwardedLoginHeader": "X-Auth-CouchDB-UserName",
+    "forwardedLoginSecret": "secretkeyforcouchdbauthtoken",
     "rules": [{
       "control": "true",
       "action": "authenticate(context,function(){proxyWork(context)})"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ldapjs": ">=0.7.x",
     "winston": ">=0.8.x",
     "async": ">=0.9.x",
-    "cookies": ">=0.5"
+    "cookies": ">=0.5",
+    "couch-proxy-auth": ">=1.0.1"
   }
 }

--- a/spec/api/proxy_spec.js
+++ b/spec/api/proxy_spec.js
@@ -38,8 +38,20 @@ test.create('Preserve cookie authentication as a fallback')
       .toss();
   })
   .toss();
+test.create('Can\'t forge proxy auth when not used')
+  .get('http://xxcouchdb.local:1337/_active_tasks')
+  .addHeader('x-auth-couchdb-username','hatter')
+  .addHeader('x-auth-couchdb-roles','_admin')
+  .expectStatus(401)
+  .toss();
 test.create('Forward authenticated login')
   .get('http://xxxcouchdb.local:1337/_users/org.couchdb.user%3Ahatter')
   .auth('hatter', 'unbirthday')
   .expectStatus(200)
+  .toss();
+test.create('Can\'t forge proxy auth')
+  .get('http://xxxcouchdb.local:1337/_active_tasks')
+  .addHeader('x-auth-couchdb-username','admin')
+  .addHeader('x-auth-couchdb-roles','_admin')
+  .expectStatus(401)
   .toss();


### PR DESCRIPTION
This uses the full X-Auth-CouchDB mechanism, including the token (thanks to couch-proxy-auth node module)

This includes two new condifugration options : `forwardedLoginSecret` and `forwardedLoginRoles` (optional). This allows to configure the couchDB upstream server with `couch_httpd_auth/proxy_use_secret` and `couch_httpd_auth/secret` so that CouchDB protects itself from forgery.

`forwardedLoginHeader` is still valid, but doesn't work if the above CouchDB options are active.

First TEST 2eb9e26 commit [fails](https://travis-ci.org/franck-eyraud/ProxyHTTP/builds/63047234) the no forge assertions because couchdb is "open", the second one 75a3c61 [passes](https://travis-ci.org/franck-eyraud/ProxyHTTP/builds/63047321) them once couchdb is protected (still uthentiating external users)