### PR TITLE
Improve handling of Basic Auth passwords (colons)

### DIFF
--- a/app/proxy.js
+++ b/app/proxy.js
@@ -243,8 +243,8 @@ function parseHttpCredentials(context) {
     if (token[0]=='Basic' && token.length>1) {
       var credentials = new Buffer(token[1], 'base64').toString().split(':');
       request.auth = {
-        login: credentials[0],
-        password: credentials.length>1 ? credentials[1] : ""
+        login: credentials.shift(),
+        password: credentials.join(":")
       };
     }
   }


### PR DESCRIPTION
In order to respect [RFC 2617](https://www.ietf.org/rfc/rfc2617.txt), the server must accept any password matching the following requirements:
```
      user-pass   = userid ":" password
      userid      = *<TEXT excluding ":">
      password    = *TEXT
```

The former implementation did not respect this, and did not take in account the `:` character in the password field.

The new implementation assumes that the usernames ends when the colon is found (so it can't contain one), and uses the other part
of the token as the password.